### PR TITLE
Avoid sorting the working set and requirements when it won't be logged.

### DIFF
--- a/src/buildout_versions/__init__.py
+++ b/src/buildout_versions/__init__.py
@@ -18,6 +18,11 @@ picked_versions = {}
 
 # code to patch in
 def _log_requirement(ws, req):
+    if not logger.isEnabledFor(logging.DEBUG):
+        # Sorting the working set and iterating over its requirements
+        # is expensive, so short cirtuit the work if it won't even be
+        # logged.
+        return
     for dist in sorted(ws):
         if req in dist.requires():
             req_ = str(req)


### PR DESCRIPTION
Merge Ross Patterson's speedup patch for zc.buildout[1] and
buildout.dumppickedversions.

[1] http://svn.zope.org/zc.buildout/trunk?rev=124059&view=rev

It's reported to result in considerable (over 2x!) speedups in some cases:
http://mail.python.org/pipermail/distutils-sig/2012-January/018268.html

Closes https://github.com/Simplistix/buildout-versions/issues/3
